### PR TITLE
[FEAT] Add message tables

### DIFF
--- a/models/marts/message/message.sql
+++ b/models/marts/message/message.sql
@@ -1,0 +1,30 @@
+with source as (
+
+    select * from {{ ref('stg_kustomer__messages') }}
+
+)
+
+, final as (
+
+    select
+        message_id as id
+        , conversation_id
+        , created_by_id as created_by
+        , customer_id
+        , modified_by_id as modified_by
+        , app
+        , null as source -- TODO identify this field
+        , channel
+        , direction
+        , preview
+        , size
+        , status -- There is also meta_status - what's the difference?
+        , meta_subject as subject
+
+    from source
+
+)
+
+select * from final
+
+        

--- a/models/marts/message/message_assigned_team.sql
+++ b/models/marts/message/message_assigned_team.sql
@@ -1,0 +1,26 @@
+with source as (
+
+    select 
+        message_id
+        , assigned_teams
+    from {{ ref('stg_kustomer__messages') }}
+
+)
+
+, unnest_array as (
+
+    {{ flatten_json_array('source', 'message_id', 'assigned_teams') }}
+        
+)
+
+, final as (
+
+    select
+        message_id
+        , assigned_teams as team_id
+
+    from unnest_array
+
+)
+
+select * from final

--- a/models/marts/message/message_assigned_user.sql
+++ b/models/marts/message/message_assigned_user.sql
@@ -1,0 +1,26 @@
+with source as (
+
+    select 
+        message_id
+        , assigned_users
+    from {{ ref('stg_kustomer__messages') }}
+
+)
+
+, unnest_array as (
+
+    {{ flatten_json_array('source', 'message_id', 'assigned_users') }}
+        
+)
+
+, final as (
+
+    select
+        message_id
+        , assigned_users as user_id
+
+    from unnest_array
+
+)
+
+select * from final

--- a/models/marts/message/message_attachment.sql
+++ b/models/marts/message/message_attachment.sql
@@ -1,0 +1,1 @@
+/* TODO - Requires additional data */

--- a/models/marts/message/message_created_by_team.sql
+++ b/models/marts/message/message_created_by_team.sql
@@ -1,0 +1,26 @@
+with source as (
+
+    select 
+        message_id
+        , created_by_teams
+    from {{ ref('stg_kustomer__messages') }}
+
+)
+
+, unnest_array as (
+
+    {{ flatten_json_array('source', 'message_id', 'created_by_teams') }}
+        
+)
+
+, final as (
+
+    select
+        message_id
+        , created_by_teams as team_id
+
+    from unnest_array
+
+)
+
+select * from final

--- a/models/marts/message/message_shortcut.sql
+++ b/models/marts/message/message_shortcut.sql
@@ -1,0 +1,26 @@
+with source as (
+
+    select 
+        message_id
+        , shortcuts
+    from {{ ref('stg_kustomer__messages') }}
+
+)
+
+, unnest_array as (
+
+    {{ flatten_json_array('source', 'message_id', 'shortcuts') }}
+        
+)
+
+, final as (
+
+    select
+        message_id
+        , {{ extract_json_field('shortcuts', ['id']) }} as shortcut_id
+
+    from unnest_array
+
+)
+
+select * from final


### PR DESCRIPTION
This adds the message mart tables:

- message
- message_assigned_team
- message_assigned_user
- message_created_by_team
- message_shortcut

In addition, I've added a placeholder file for `message_attachment` for when https://github.com/brooklyn-data/tap-kustomer/issues/14 is resolved.

This relies on #2  and #1 