### PR TITLE
Remove logic from other warehouse type

### DIFF
--- a/models/staging/_sources.yml
+++ b/models/staging/_sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: kustomer
-    database: "{% if target.type != 'spark'%}{{ var('kustomer_database', target.database) }}{% endif %}"
+    database: "{{ var('kustomer_database', target.database) }}"
     schema: "{{ var ('kustomer_schema', target.schema ) }}"
     tables:
       - name: attachments


### PR DESCRIPTION
Remove reference to Spark that would only be relevant if supporting multiple warehouses. This resolves #12 